### PR TITLE
在题目列表页面增加了顶部标签 / Added head tags on the problem list page

### DIFF
--- a/web/blueprints/admin.py
+++ b/web/blueprints/admin.py
@@ -103,7 +103,7 @@ def show_problem_detail(pid):
 
 @bp.post("/api/set_siteconfig")
 def api_set_siteconfig():
-    keys = ["site_name", "is_allow_register", "use_gravatar", "use_local_resources", "start_time", "end_time", "decay_lambda", "userinfo_extra_fields"]
+    keys = ["site_name", "is_allow_register", "use_gravatar", "use_local_resources", "start_time", "end_time", "decay_lambda", "userinfo_extra_fields", "head_tags"]
 
     config_items = [[request.form.get(key).strip(), key] for key in keys]
 

--- a/web/blueprints/problem.py
+++ b/web/blueprints/problem.py
@@ -5,6 +5,7 @@ from util.flag_check import check_flag
 from traceback import format_exc
 from util.wrapper import login_required, admin_required
 from datetime import datetime, timedelta
+import collections
 
 bp = Blueprint('problem', __name__, url_prefix='/problem')
 
@@ -38,6 +39,17 @@ SELECT r.*, solve_info FROM r LEFT JOIN solves ON r.id = solves.problem_id WHERE
     for x in g.problems:
         x['tag_list'] = parse_tags(x.pop('tag'))
         x['task_list'] = parse_tags(x.pop('tasks'))
+
+    # 对所有题目的 tag 进行计数
+    all_tags = [ tag for x in g.problems for tag in x['tag_list'] ]
+    g.tags_count = collections.Counter(all_tags)
+
+    # 获取 head_tags
+    with db_pool.connection() as conn:
+        dbres = conn.execute(
+            "SELECT config_value FROM site_config WHERE config_key = 'head_tags'"
+        ).fetchone()
+        g.head_tags = parse_tags(dbres["config_value"])
 
     return render_template('problem/list.html')
 

--- a/web/blueprints/problem.py
+++ b/web/blueprints/problem.py
@@ -41,7 +41,7 @@ SELECT r.*, solve_info FROM r LEFT JOIN solves ON r.id = solves.problem_id WHERE
         x['task_list'] = parse_tags(x.pop('tasks'))
 
     # 对所有题目的 tag 进行计数
-    all_tags = [ tag for x in g.problems for tag in x['tag_list'] ]
+    all_tags = [ tag.lower() for x in g.problems for tag in x['tag_list'] ]
     g.tags_count = collections.Counter(all_tags)
 
     # 获取 head_tags

--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -60,3 +60,14 @@ img {
 }
 
 .toast-container {}
+
+.flex-center {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    gap: 8px 6px;
+}
+
+.head-tags .ui.label.basic {
+    background: transparent !important;
+}

--- a/web/templates/admin/site_config.html
+++ b/web/templates/admin/site_config.html
@@ -78,11 +78,9 @@
 
             <div class="field">
                 <label>Tags to show below the search bar</label>
-                <div class="ui calendar" id="head_tags">
-                    <div class="ui fluid input left icon">
-                      <i class="tags icon"></i>
-                      <input type="text" name="head_tags" placeholder="eg: web | pwn" value="{{site_config['head_tags']}}">
-                    </div>
+                <div class="ui fluid input left icon">
+                    <i class="tags icon"></i>
+                    <input type="text" name="head_tags" placeholder="eg: web | pwn" value="{{site_config['head_tags']}}">
                 </div>
             </div>
 

--- a/web/templates/admin/site_config.html
+++ b/web/templates/admin/site_config.html
@@ -76,6 +76,16 @@
                 </div>
             </div>
 
+            <div class="field">
+                <label>Tags to show below the search bar</label>
+                <div class="ui calendar" id="head_tags">
+                    <div class="ui fluid input left icon">
+                      <i class="tags icon"></i>
+                      <input type="text" name="head_tags" placeholder="eg: web | pwn" value="{{site_config['head_tags']}}">
+                    </div>
+                </div>
+            </div>
+
             <script>
                 $('#start_time').calendar({
                     formatter: {

--- a/web/templates/problem/list.html
+++ b/web/templates/problem/list.html
@@ -13,7 +13,17 @@
 
 <div class="ui divider hidden"></div>
 
-
+<div class="head-tags ui container">
+    <div class="ui flex-center">
+        {% for tag in g.head_tags %}
+            <a class="ui large label basic primary" data-label="tag" onclick="set_tag('{{tag}}')">
+                {{tag}}
+                <div class="detail">{{g.tags_count[tag]}}</div>
+            </a>
+        {% endfor %}
+    </div>
+    <div class="ui divider hidden"></div>
+</div>
 
 <div class="ui container">
     <table class="ui basic selectable unstackable large table">

--- a/web/templates/problem/list.html
+++ b/web/templates/problem/list.html
@@ -16,9 +16,9 @@
 <div class="head-tags ui container">
     <div class="ui flex-center">
         {% for tag in g.head_tags %}
-            <a class="ui large label basic primary" data-label="tag" onclick="set_tag('{{tag}}')">
+            <a class="ui large label basic primary" data-label="tag" onclick="set_tag('{{tag.lower()}}')">
                 {{tag}}
-                <div class="detail">{{g.tags_count[tag]}}</div>
+                <div class="detail">{{g.tags_count[tag.lower()]}}</div>
             </a>
         {% endfor %}
     </div>

--- a/web/util/click.py
+++ b/web/util/click.py
@@ -256,6 +256,7 @@ def check(s):
                     ["userinfo_extra_fields", "[]"],
                     ["start_time", ""],
                     ["end_time", ""],
+                    ["head_tags", ""]
                 ],
             )
 


### PR DESCRIPTION
- 变化如题
- 更新后需要执行 `flask init-db`，或手动在数据库中添加一行
- 为了一致性，初始化数据库时，没有预设标签，可以考虑改为初始化时就预设一组常用标签
- 标签计数大小写不敏感，与搜索栏的表现一致
- 多行标签能正确显示，会自动换行