### PR TITLE
Use toast to show copy feedback

### DIFF
--- a/web/templates/problem/detail.html
+++ b/web/templates/problem/detail.html
@@ -206,7 +206,7 @@
                     const inputElement = document.querySelector("#instance_input")
                     inputElement.select()
                     document.execCommand('copy')
-                    alert("Successfully copied to clipboard!")
+                    $.toast({ class: "success", title: "Copied", showProgress: "button", message: "Successfully copied to clipboard!"})
                 }
             </script>
             {% endif %}


### PR DESCRIPTION
Use toast to show copy feedback instead of alert, so that it won't block user actions anymore.