### PR TITLE
Adapting to Docker SDK v2

### DIFF
--- a/platform-init.py
+++ b/platform-init.py
@@ -9,10 +9,10 @@ compose = compose.replace('$PGSQL_PASSWORD$', pgsql_passwd)
 open(os.path.join('pgsql', 'docker-compose.yml'), 'w').write(compose)
 
 os.chdir('pgsql')
-os.system('docker-compose down -t 0')
+os.system('docker compose down -t 0')
 os.system('rm -rf pgsql_data')
 
-os.system('docker-compose up -d')
+os.system('docker compose up -d')
 os.chdir('..')
 
 print('DB init ok. sleep 10s.')

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Latest Debian is recommended.
 Install requirements:
 
 ```bash
-apt install nginx docker-compose tmux
+apt install nginx docker compose tmux
 apt install python3 python3-dotenv python3-flask python3-psycopg-pool python3-passlib python3-psutil python3-gevent python3-rich python3-pycryptodome gunicorn
 ```
 
@@ -71,7 +71,7 @@ Now Blueberry platform is avaliable on port 80.
 Build the demo challenge `runma`:
 ```
 cd problems/runma
-docker-compose build
+docker compose build
 ```
 
 Start the container manager:


### PR DESCRIPTION
- Fallback from `ContainerConfig` to `Config` when accessing `ExposedPorts`
- Replaced deprecated `docker-compose` command with the new `docker compose`